### PR TITLE
Initialize Terraform provider skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Seeweb Terraform Provider
+
+This repository contains the source code for the Seeweb Terraform provider. The provider is built using the Terraform Plugin Framework and exposes resources and data sources for managing Seeweb services.
+
+## Project Structure
+
+- **cmd/seeweb**: Entrypoint for the Terraform provider plugin.
+- **internal/provider**: Implementation of the provider logic.
+- **internal/resource**: Implementation of Terraform resources.
+- **internal/data**: Implementation of Terraform data sources.
+- **examples/**: Example Terraform configurations.
+- **docs/**: Documentation for resources, data sources, and provider usage.
+

--- a/cmd/seeweb/main.go
+++ b/cmd/seeweb/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/seeweb/seeweb-tf-provider/internal/provider"
+)
+
+func main() {
+	providerserver.Serve(context.Background(), provider.New, providerserver.ServeOpts{
+		Address: "registry.terraform.io/seeweb/seeweb",
+	})
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+# Seeweb Provider
+
+The Seeweb provider enables management of Seeweb resources using Terraform.
+
+## Usage
+
+Refer to the examples for how to configure the provider and use resources.

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    seeweb = {
+      source  = "seeweb/seeweb"
+      version = "0.1.0"
+    }
+  }
+}
+
+provider "seeweb" {}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/seeweb/seeweb-tf-provider
+
+go 1.24.3

--- a/internal/data/dummy_data_source.go
+++ b/internal/data/dummy_data_source.go
@@ -1,0 +1,24 @@
+package data
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+// DummyDataSource is a placeholder Terraform data source.
+type DummyDataSource struct{}
+
+func (d *DummyDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "dummy"
+}
+
+func (d *DummyDataSource) Schema(_ context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	// Data source schema will be defined here.
+}
+
+func (d *DummyDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	// Read implementation.
+}
+
+var _ datasource.DataSource = (*DummyDataSource)(nil)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,0 +1,47 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+
+	"github.com/seeweb/seeweb-tf-provider/internal/data"
+	"github.com/seeweb/seeweb-tf-provider/internal/resource"
+)
+
+// New returns a new instance of the Seeweb provider.
+func New() provider.Provider {
+	return &seewebProvider{}
+}
+
+type seewebProvider struct{}
+
+func (p *seewebProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = "seeweb"
+	resp.Version = "0.1.0"
+}
+
+func (p *seewebProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
+	// No provider-level configuration yet.
+}
+
+func (p *seewebProvider) Configure(_ context.Context, _ provider.ConfigureRequest, _ *provider.ConfigureResponse) {
+	// No-op configuration for now.
+}
+
+func (p *seewebProvider) Resources(_ context.Context) []func() provider.Resource {
+	return []func() provider.Resource{
+		func() provider.Resource { return &resource.DummyResource{} },
+	}
+}
+
+func (p *seewebProvider) DataSources(_ context.Context) []func() provider.DataSource {
+	return []func() provider.DataSource{
+		func() provider.DataSource { return &data.DummyDataSource{} },
+	}
+}
+
+var _ provider.Provider = (*seewebProvider)(nil)
+
+var _ providerserver.ProviderServer = &providerserver.SimpleProviderServer{Provider: New()}

--- a/internal/resource/dummy_resource.go
+++ b/internal/resource/dummy_resource.go
@@ -1,0 +1,36 @@
+package resource
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// DummyResource is a placeholder Terraform resource.
+type DummyResource struct{}
+
+func (r *DummyResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "dummy"
+}
+
+func (r *DummyResource) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	// Resource schema will be defined here.
+}
+
+func (r *DummyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// Create implementation.
+}
+
+func (r *DummyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Read implementation.
+}
+
+func (r *DummyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Update implementation.
+}
+
+func (r *DummyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// Delete implementation.
+}
+
+var _ resource.Resource = (*DummyResource)(nil)


### PR DESCRIPTION
## Summary
- set up Go module and stub provider
- add placeholder resource and data source
- add docs and example configuration

## Testing
- `go build ./...` *(fails: no required module provides package)*

------
https://chatgpt.com/codex/tasks/task_e_687e431f945883218859935a41d750c3